### PR TITLE
More robust creation of columns measure and n_pct

### DIFF
--- a/R/explore.R
+++ b/R/explore.R
@@ -2484,28 +2484,35 @@ explore_tbl <- function(data)  {
   n_var <- nrow(d)
 
   # prepare "all variables"
-  bar1 <- d %>% count(type)
-  bar1$measure <- "all"
-  bar1$n_pct <- bar1$n / n_var * 100
+  bar1 <- d %>%
+    count(type) %>%
+    mutate(
+      measure = "all",
+      n_pct = n / n_var * 100
+    )
 
   # prepare "no variance"
   suppressWarnings(
     bar2 <- d %>%
       filter(type != "oth") %>%
       filter(unique == 1) %>%
-      count(type)
+      count(type) %>%
+      mutate(
+        measure = "no variance",
+        n_pct = n / n_var * 100
+      )
   )
-  bar2$measure <- "no variance"
-  bar2$n_pct <- bar2$n / n_var * 100
 
   # prepare "with NA"
   suppressWarnings(
     bar3 <- d %>%
       filter(na > 0) %>%
-      count(type)
+      count(type) %>%
+      mutate(
+        measure = "with NA",
+        n_pct = n / n_var * 100
+      )
   )
-  bar3$measure <- "with NA"
-  bar3$n_pct <- bar3$n / n_var * 100
 
   # prepare plot
   bar <- bind_rows(bar1, bar2, bar3)


### PR DESCRIPTION
Columns `measure` and `n_pct` are created using a `mutate()` rather than using `$<-`. This is more robust in case the data frame has 0 rows, which happens because of this fix in dplyr. see https://github.com/tidyverse/dplyr/issues/4460 https://github.com/tidyverse/dplyr/issues/4497 for more details. 

Without this fix, `explore` fails against the soon released `dplyr` 0.8.4: 

````
## explore

<details>

* Version: 0.5.0
* Source code: https://github.com/cran/explore
* URL: http://github.com/rolkra/explore
* Date/Publication: 2019-09-19 12:40:02 UTC
* Number of recursive dependencies: 78

Run `revdep_details(,"explore")` for more info

</details>

## Newly broken

*   checking examples ... ERROR
    ```
    Running examples in ‘explore-Ex.R’ failed
    The error most likely occurred in:
    
    > ### Name: explore_tbl
    > ### Title: Explore table
    > ### Aliases: explore_tbl
    > 
    > ### ** Examples
    > 
    > explore_tbl(iris)
    Error in `$<-.data.frame`(`*tmp*`, "measure", value = "no variance") : 
      replacement has 1 row, data has 0
    Calls: explore_tbl -> $<- -> $<-.data.frame
    Execution halted
    ```
````